### PR TITLE
Fix JSON formatting by removing extra brace

### DIFF
--- a/presets.json
+++ b/presets.json
@@ -94,7 +94,6 @@
         "executable": "PEAK.exe",
         "path": "Games/PEAK"
     },
-    },
     {
         "name": "Perplexity",
         "executable": "comet.exe",


### PR DESCRIPTION
Removed an extra closing brace from the presets.json file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a configuration syntax error that could prevent presets from loading in some environments. No changes to available presets or behavior.
* **Chores**
  * Cleaned up configuration formatting for improved stability and compatibility with strict JSON parsers.
  * Ensures smoother startup and reduces risk of parsing-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->