### PR TITLE
Update presets.json

### DIFF
--- a/presets.json
+++ b/presets.json
@@ -155,6 +155,11 @@
     "path": "Tom Clancy's Rainbow Six Siege"
   },
   {
+    "name": "Risk of Rain 2: Alloyed Collective",
+    "executable": "Risk of Rain 2.exe",
+    "path": "Risk of Rain 2"
+  },
+  {
     "name": "Rust",
     "executable": "RustClient.exe",
     "path": "Rust"


### PR DESCRIPTION
Added Risk of Rain 2: Alloyed Collective to claim that Gup Avatar Decoration

its just risk of rain 2 executable, alloyed collective is a dlc iirc, i used "Risk of Rain 2: Alloyed Collective" name for clarity and avoid confusion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new preset for Risk of Rain 2: Alloyed Collective.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->